### PR TITLE
docs: Fixes README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ with:
   license: 'Apache-2.0'
   owner: 'François-Guillaume Fernandez'
   starting-year: 2022
-  ignores: 'version.py,__init__.py'
+  ignore-files: 'version.py,__init__.py'
+  ignore-folders: '.github/'
 ```
 
 


### PR DESCRIPTION
This PR fixes the usage example in the README.