### PR TITLE
fix(src): update the suggestion when headers are invalid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "validate-python-headers"
-version = "0.4.0.dev0"
+version = "0.5.0.dev0"
 description = "Python header validator"
 license = "Apache-2.0"
 authors = ["François-Guillaume Fernandez <fg-feedback@protonmail.com>"]

--- a/src/validate_headers.py
+++ b/src/validate_headers.py
@@ -72,7 +72,7 @@ def get_header_options(
             for copyright_notice in copyright_notices[:-1]
             for license_notice in license_notices
         ]
-        + [[*copyright_notices[-1], BLANK_LINE, license_notice[0]]]
+        + [[*copyright_notices[-1], BLANK_LINE, *license_notices[0]]]
     )
 
 

--- a/src/validate_headers.py
+++ b/src/validate_headers.py
@@ -57,17 +57,23 @@ def get_header_options(
 
     # Header build
     year_options = [f"{current_year}"] + [f"{year}-{current_year}" for year in range(starting_year, current_year)]
+    #  last element is the example for the error message
+    year_options.append(f"{current_year}" if starting_year == current_year else f"<FILE_CREATION_YEAR>-{current_year}")
     copyright_notices = [[f"# Copyright (C) {year_str}, {owner}.\n"] for year_str in year_options]
 
-    return [
-        [*SHEBANG, BLANK_LINE, *copyright_notice, BLANK_LINE, *license_notice]
-        for copyright_notice in copyright_notices
-        for license_notice in license_notices
-    ] + [
-        [*copyright_notice, BLANK_LINE, *license_notice]
-        for copyright_notice in copyright_notices
-        for license_notice in license_notices
-    ]
+    return (
+        [
+            [*SHEBANG, BLANK_LINE, *copyright_notice, BLANK_LINE, *license_notice]
+            for copyright_notice in copyright_notices[:-1]
+            for license_notice in license_notices
+        ]
+        + [
+            [*copyright_notice, BLANK_LINE, *license_notice]
+            for copyright_notice in copyright_notices[:-1]
+            for license_notice in license_notices
+        ]
+        + [[*copyright_notices[-1], BLANK_LINE, license_notice[0]]]
+    )
 
 
 def main(args) -> None:
@@ -89,7 +95,7 @@ def main(args) -> None:
             if source_path.name in ignored_files or any(folder in source_path.parents for folder in ignored_folders):
                 continue
             # Parse header
-            header_length = max(len(option) for option in header_options)
+            header_length = max(len(option) for option in header_options[:-1])
             current_header = []
             with source_path.open() as f:
                 for idx, line in enumerate(f):
@@ -99,7 +105,7 @@ def main(args) -> None:
             # Validate it
             if not any(
                 "".join(current_header[: min(len(option), len(current_header))]) == "".join(option)
-                for option in header_options
+                for option in header_options[:-1]
             ):
                 invalid_files.append(source_path)
 


### PR DESCRIPTION
This PR updates the suggestion in the error message from:
```
Your header should look like:

# Copyright (C) 2023-2024, Pyronear.

# This program is licensed under the Apache License 2.0.
```

to
```
Your header should look like:

# Copyright (C) <FILE_CREATION_YEAR>-2024, Pyronear.

# This program is licensed under the Apache License 2.0.
```
or if the project creation year is the current one:
```
Your header should look like:

# Copyright (C) <FILE_CREATION_YEAR>, Pyronear.

# This program is licensed under the Apache License 2.0.
```

Closes #17