### PR TITLE
ci(push): fix GHCR docker push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,4 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to GitHub container registry
-        run: |
-          docker tag openapm/backend:latest ghcr.io/${{ github.repository_owner }}/${{ env.BACKEND_IMAGE }}:latest
-          docker push ghcr.io/${{ github.repository_owner }}/${{ env.BACKEND_IMAGE }}:latest
+        run: make push

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKERFILE_PATH = ./Dockerfile
 PYPROJECT_FILE = ./pyproject.toml
 LOCK_FILE = ./uv.lock
 REQ_FILE = ./requirements.txt
-DOCKER_NAMESPACE ?= frgfm
+DOCKER_NAMESPACE ?= ghcr.io/frgfm
 DOCKER_REPO ?= validate-python-headers
 DOCKER_TAG ?= latest
 


### PR DESCRIPTION
This PR fixes the job to publish the docker image which had a wrong label name